### PR TITLE
fix: error display should not also show empty orders message

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -148,15 +148,17 @@ class OrderHistoryPage extends React.Component {
       loadingError,
       orders,
     } = this.props;
-    const loaded = !loading;
+    const loaded = !loading && !loadingError;
+    const hasOrders = orders.length > 0;
+
     return (
       <div className="page__order-history container-fluid py-5">
         <h1>
           {this.props.intl.formatMessage(messages['ecommerce.order.history.page.heading'])}
         </h1>
         {loadingError ? this.renderError() : null}
-        {loaded && orders.length > 0 ? this.renderOrdersTable() : null}
-        {loaded && orders.length === 0 ? this.renderEmptyMessage() : null}
+        {loaded && hasOrders ? this.renderOrdersTable() : null}
+        {loaded && !hasOrders ? this.renderEmptyMessage() : null}
         {loading ? this.renderLoading() : null}
       </div>
     );


### PR DESCRIPTION
Prevent this from happening:
<img width="419" alt="Screen Shot 2019-04-18 at 3 34 07 PM" src="https://user-images.githubusercontent.com/1615421/56386311-6de03900-61ef-11e9-8082-e2b63416194a.png">
