### PR TITLE
fix: add error logging and remove use of unreliable product.id

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -70,11 +70,10 @@ class OrderHistoryPage extends React.Component {
 
   renderLineItems(lineItems) {
     return lineItems.map(({
-      itemId,
       description,
       quantity,
     }) => (
-      <p className="d-flex" key={itemId}>
+      <p className="d-flex" key={description}>
         <span className="mr-3">{quantity}x</span>
         <span>{description}</span>
       </p>
@@ -173,7 +172,6 @@ OrderHistoryPage.propTypes = {
     receiptUrl: PropTypes.string,
     currency: PropTypes.string,
     lineItems: PropTypes.arrayOf(PropTypes.shape({
-      itemId: PropTypes.number,
       title: PropTypes.string,
       quantity: PropTypes.number,
       description: PropTypes.string,

--- a/src/order-history/actions.js
+++ b/src/order-history/actions.js
@@ -20,11 +20,6 @@ export const fetchOrdersSuccess = result => ({
   payload: result,
 });
 
-export const fetchOrdersFailure = error => ({
-  type: FETCH_ORDERS.FAILURE,
-  payload: { error },
-});
-
 export const fetchOrdersReset = () => ({
   type: FETCH_ORDERS.RESET,
 });

--- a/src/order-history/reducer.js
+++ b/src/order-history/reducer.js
@@ -30,12 +30,6 @@ const orderHistoryPage = (state = initialState, action) => {
         currentPage: action.payload.currentPage,
         loading: false,
       };
-    case FETCH_ORDERS.FAILURE:
-      return {
-        ...state,
-        loadingError: action.payload.error,
-        loading: false,
-      };
     case FETCH_ORDERS.RESET:
       return {
         ...state,

--- a/src/order-history/saga.js
+++ b/src/order-history/saga.js
@@ -1,11 +1,13 @@
 import { call, put, takeEvery } from 'redux-saga/effects';
+import { push } from 'connected-react-router';
+import LoggingService from '@edx/frontend-logging';
 
 // Actions
 import {
   FETCH_ORDERS,
   fetchOrdersBegin,
   fetchOrdersSuccess,
-  fetchOrdersFailure,
+  // fetchOrdersFailure,
   fetchOrdersReset,
 } from './actions';
 
@@ -17,13 +19,12 @@ export function* handleFetchOrders(action) {
   const { username } = action.payload;
   try {
     yield put(fetchOrdersBegin());
-
     const result = yield call(OrdersApiService.getOrders, username, action.payload.pageToFetch);
     yield put(fetchOrdersSuccess(result));
     yield put(fetchOrdersReset());
   } catch (e) {
-    // LoggingService.logAPIErrorResponse(e);
-    yield put(fetchOrdersFailure(e.message));
+    LoggingService.logAPIErrorResponse(e);
+    yield put(push('/error'));
   }
 }
 

--- a/src/order-history/saga.js
+++ b/src/order-history/saga.js
@@ -7,7 +7,6 @@ import {
   FETCH_ORDERS,
   fetchOrdersBegin,
   fetchOrdersSuccess,
-  // fetchOrdersFailure,
   fetchOrdersReset,
 } from './actions';
 

--- a/src/order-history/service.js
+++ b/src/order-history/service.js
@@ -40,12 +40,10 @@ export async function getOrders(username, page = 1, pageSize = 20) {
     date_placed, // eslint-disable-line camelcase
   }) => {
     const lineItems = lines.map(({
-      product,
       title,
       quantity,
       description,
     }) => ({
-      itemId: product.id,
       title,
       quantity,
       description,


### PR DESCRIPTION
- use line item description instead of product id because product is sometimes null
- we don't expect any errors from our API call so add error logging and push the user to the error page