### PR TITLE
feat: add mobile table view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8571,8 +8571,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8593,14 +8592,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8615,20 +8612,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8745,8 +8739,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8758,7 +8751,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8773,7 +8765,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8781,14 +8772,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8807,7 +8796,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8888,8 +8876,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8901,7 +8888,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8987,8 +8973,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9024,7 +9009,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9044,7 +9028,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9088,14 +9071,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-dom": "^16.8.3",
     "react-intl": "^2.8.0",
     "react-redux": "^5.1.1",
+    "react-responsive": "^6.1.1",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-transition-group": "^2.5.3",

--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -120,7 +120,7 @@ class OrderHistoryPage extends React.Component {
     return this.getTableData().map(({
       description, datePlaced, total, orderId, receiptUrl,
     }) => (
-      <div className="border-bottom py-3">
+      <div className="border-bottom py-3" key={orderId}>
         <dl>
           <dt>
             {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items'])}

--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape, FormattedNumber, FormattedDate } from 'react-intl';
 import { Table, Hyperlink, Pagination } from '@edx/paragon';
+import MediaQuery from 'react-responsive';
 
 import messages from './OrderHistoryPage.messages';
 
@@ -115,6 +116,34 @@ class OrderHistoryPage extends React.Component {
     );
   }
 
+  renderMobileOrdersTable() {
+    return this.getTableData().map(({
+      description, datePlaced, total, orderId, receiptUrl,
+    }) => (
+      <div className="border-bottom py-3">
+        <dl>
+          <dt>
+            {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.items'])}
+          </dt>
+          <dd>{description}</dd>
+          <dt>
+            {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.date.placed'])}
+          </dt>
+          <dd>{datePlaced}</dd>
+          <dt>
+            {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.total.cost'])}
+          </dt>
+          <dd>{total}</dd>
+          <dt>
+            {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.number'])}
+          </dt>
+          <dd>{orderId}</dd>
+        </dl>
+        <p>{receiptUrl}</p>
+      </div>
+    ));
+  }
+
   renderEmptyMessage() {
     return (
       <p>
@@ -154,7 +183,16 @@ class OrderHistoryPage extends React.Component {
           {this.props.intl.formatMessage(messages['ecommerce.order.history.page.heading'])}
         </h1>
         {loadingError ? this.renderError() : null}
-        {loaded && hasOrders ? this.renderOrdersTable() : null}
+        {loaded && hasOrders ? (
+          <React.Fragment>
+            <MediaQuery query="(max-width: 768px)">
+              {this.renderMobileOrdersTable()}
+            </MediaQuery>
+            <MediaQuery query="(min-width: 769px)">
+              {this.renderOrdersTable()}
+            </MediaQuery>
+          </React.Fragment>
+        ) : null}
         {loaded && !hasOrders ? this.renderEmptyMessage() : null}
         {loading ? this.renderLoading() : null}
       </div>


### PR DESCRIPTION
Uses react-responsive (new dependency) to swap table rendering.
On mobile the data is rendered as a series of `div` containing a `dl`.

<img width="375" alt="Screen Shot 2019-04-25 at 9 52 50 AM" src="https://user-images.githubusercontent.com/1615421/56740984-fe62d000-673f-11e9-9e67-1f972cffda10.png">
