### PR TITLE
Add header for view order details.

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -104,7 +104,7 @@ class OrderHistoryPage extends React.Component {
             key: 'orderId',
           },
           {
-            label: '',
+            label: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.details']),
             key: 'receiptUrl',
           },
         ]}

--- a/src/order-history/OrderHistoryPage.messages.jsx
+++ b/src/order-history/OrderHistoryPage.messages.jsx
@@ -46,6 +46,11 @@ const messages = defineMessages({
     defaultMessage: 'Order number',
     description: 'The column label for Order number in the order history table.',
   },
+  'ecommerce.order.history.table.column.order.details': {
+    id: 'ecommerce.order.history.table.column.order.details',
+    defaultMessage: 'Order details',
+    description: 'The column label for Order details in the order history table.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## [PROD-607](https://openedx.atlassian.net/browse/PROD-607)
### Description
Order detail table does not have header for 'view order details' column which may affect user experience in terms of a11y.In this PR, header text is added to order table.
