### PR TITLE
VAN-44: Add hotjar suppression to orderId

### DIFF
--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -42,7 +42,11 @@ class OrderHistoryPage extends React.Component {
           {this.props.intl.formatMessage(messages['ecommerce.order.history.view.order.detail'])}
         </Hyperlink>
       ),
-      orderId,
+      orderId: (
+        <span data-hj-suppress>
+          {orderId}
+        </span>
+      ),
     }), this);
   }
 


### PR DESCRIPTION
Hotjar is a behavior analytics tool that analyses website use, providing feedback through tools such as heatmaps, session recordings, and surveys. Before we enable hotjar we have to suppress all PII and sensitive information so that screen recorder doesn’t capture it. Adding a `data-hj-suppress` attribute around the sensitive data marks the field as suppressed for hotjar and shows asterisks instead of text.
<img width="733" alt="Screenshot 2020-09-16 at 10 03 02 AM" src="https://user-images.githubusercontent.com/40633976/93294490-10955080-f804-11ea-9d39-dff3458741fa.png">


For Ecommerce MFE, pages identified are:
- ConnectedOrderHistoryPage (suppression needed)
- Notfoundpage (no suppression needed)
- Header already covered in https://github.com/edx/frontend-component-header-edx/pull/98

Code changes:
Added Hotjar suppression to orderId on the order history page. This will suppress PII when we enable Hotjar Analytics for ecommerce MFE.

Ticket: [VAN-44](https://openedx.atlassian.net/browse/VAN-44)