### PR TITLE
Update readme to reflect removal of purgecss

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,11 +46,6 @@ edX <https://github.com/edx/edx-developer-docs/blob/5191e800bf16cf42f25c58c58f98
 
 ----------
 
-Notes
------
-
-The production Webpack configuration for this repo uses `Purgecss <https://www.purgecss.com/>`__ to remove unused CSS from the production css file. In ``webpack.prod.config.js`` the Purgecss plugin is configured to scan directories to determine what css selectors should remain. Currently the src/ directory is scanned along with all ``@edx/frontend-component*`` node modules and ``@edx/paragon``. **If you add and use a component in this repo that relies on HTML classes or ids for styling you must add it to the Purgecss configuration or it will be unstyled in the production build.**
-
 .. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-ecommerce.svg?branch=master
    :target: https://travis-ci.org/edx/frontend-app-ecommerce
 .. |Codecov| image:: https://img.shields.io/codecov/c/github/edx/frontend-app-ecommerce


### PR DESCRIPTION
## What are we doing
Removing references to the PurgeCSS library from the Readme doc

## Why are we doing this
To eliminate confusion in the Readme about a library that is no longer used. The library was intentionally removed in https://github.com/edx/frontend-app-ecommerce/pull/73 because the library is a somewhat dangerous way to cut down on css bloat and for this particular app, it was decided that performance was less important than the risk incurred by using purgecss.