### PR TITLE
Set NODE_ENV='production' in .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-NODE_ENV=null
+NODE_ENV='production'
 BASE_URL=null
 LMS_BASE_URL=null
 CREDENTIALS_BASE_URL=null


### PR DESCRIPTION
## What are we doing?
Set the `NODE_ENV='production'` in the `.env` file, similar to what newer mfes (e.g. https://github.com/edx/frontend-app-payment/blob/master/.env#L1) do

## Why are we doing this
We're getting an error in the Stage + Prod environments's Javascript console about ```redux.js:307 You are currently using minified code outside of NODE_ENV === "production". This means that you are running a slower development build of Redux. You can use loose-envify (https://github.com/zertosh/loose-envify) for browserify or setting mode to production in webpack (https://webpack.js.org/concepts/mode/) to ensure you have the correct code for your production build.```

We think this is due to the fact that the env isn't specified when the app starts (it's set to "null" in the prod environment), which we think is ultimately pulled from the .env file. This doesn't appear to be meaningfully impacting any functionality in production (other than the error in the console), but in theory, there are two side effects:
1. Third party packages (e.g. redux) may rely on the node environment to determine if they need to do extra safety checks that would only be done in development
2. There may be additional optimizations that will only be done in a production environment to speed things up that may not be done in development, so the production environment may not be as fast as it can be. 

This flag is already set in the `.env.development` file, which should override the `.env` config in the correct environment.

Image of the error (seen in both stage and prod):
<img width="1089" alt="Screen Shot 2021-01-25 at 3 58 18 PM" src="https://user-images.githubusercontent.com/34042537/105862129-71584500-5fbd-11eb-9e31-e3f651ea417a.png">

## How was this tested?
- Local environment looks fine
- Will need to merge to see if this fixes the issue in stage; if successful, then deploy to prod