### PR TITLE
Update README to recommend `npm ci`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ In this project, install requirements and start the development server by runnin
 
 .. code:: bash
 
-   npm install
+   npm ci
    npm start # The server will run on port 1996
 
 Once the dev server is up visit http://localhost:1996.

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ In this project, install requirements and start the development server by runnin
 
 Once the dev server is up visit http://localhost:1996.
 
-Note: ``npm ci`` is recommended over ``npm install`` to match the way CI and production builds work and avoid unintentional changes to `package_lock.json` when doing other work.
+Note: ``npm ci`` is recommended over ``npm install`` to match the way CI and production builds work and avoid unintentional changes to ``package_lock.json`` when doing other work.
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ In this project, install requirements and start the development server by runnin
 
 Once the dev server is up visit http://localhost:1996.
 
+Note: ``npm ci`` is recommended over ``npm install`` to match the way CI and production builds work and avoid unintentional changes to `package_lock.json` when doing other work.
+
 ----------
 
 Configuration and Deployment


### PR DESCRIPTION
Recommend `npm ci` over `npm install` to minimize package_lock changes and match CI and prod builds