### PR TITLE
build: include this repo in Open edX releases

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,6 +1,6 @@
 # This file describes this Open edX repo, as described in OEP-2:
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
-nick: ecom
 oeps: {}
-owner: edx/arch-team
+openedx-release:
+  ref: master


### PR DESCRIPTION
Also removed two obsolete keys.

This repo should be included in Open edX releases, but the openedx.yaml didn't correctly indicate this.  Now it does.