### PR TITLE
fix: Disable Subscriptions section in Order History

### DIFF
--- a/src/subscriptions/reducer.js
+++ b/src/subscriptions/reducer.js
@@ -6,7 +6,7 @@ export const initialState = {
   subscriptions: [],
   stripeError: false,
   stripeLoading: false,
-  shouldShowSubscriptionsSection: true,
+  shouldShowSubscriptionsSection: false, // B2C subscriptions sunsetting
 };
 
 const subscriptionsReducer = (state = initialState, action = {}) => {


### PR DESCRIPTION
[REV-4135](https://2u-internal.atlassian.net/browse/REV-4135).

Disabling the section that shows B2C Subscriptions history. This will be for all learners, regardless if they had subscriptions in the past or not.

We will not clean up all of the subscriptions code we added since ecommerce MFE is going away.

**Before:**
<img width="1434" alt="Screenshot 2024-08-14 at 10 22 30 AM" src="https://github.com/user-attachments/assets/5ac23377-6cc4-438b-abbb-9cdcfb47f19d">



**After:**
<img width="1433" alt="Screenshot 2024-08-14 at 10 22 55 AM" src="https://github.com/user-attachments/assets/50b9f66e-6a1c-4212-9426-e56a8866d56d">


